### PR TITLE
Replace defunct buildjet runners with GitHub-hosted runners

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,13 +1,5 @@
 self-hosted-runner:
   labels:
     - qemu-host
-    - buildjet-2vcpu-ubuntu-2204
-    - buildjet-4vcpu-ubuntu-2204
-    - buildjet-8vcpu-ubuntu-2204
-    - buildjet-16vcpu-ubuntu-2204
-    - buildjet-32vcpu-ubuntu-2204
-    - buildjet-2vcpu-ubuntu-2204-arm
-    - buildjet-4vcpu-ubuntu-2204-arm
-    - buildjet-8vcpu-ubuntu-2204-arm
-    - buildjet-16vcpu-ubuntu-2204-arm
-    - buildjet-32vcpu-ubuntu-2204-arm
+    - ubuntu-large
+    - github-linux-arm64-8core

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
-    runs-on: buildjet-8vcpu-ubuntu-2204-arm
+    runs-on: github-linux-arm64-8core
     container:
       image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
       options: --platform linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: buildjet-8vcpu-ubuntu-2204
+          - arch: ubuntu-large
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             label: amd64
-          - arch: buildjet-8vcpu-ubuntu-2204-arm
+          - arch: github-linux-arm64-8core
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             label: arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
        matrix:
         include:
-          - arch: buildjet-8vcpu-ubuntu-2204
+          - arch: ubuntu-large
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
             label: amd64
-          - arch: buildjet-8vcpu-ubuntu-2204-arm
+          - arch: github-linux-arm64-8core
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
             label: arm64


### PR DESCRIPTION
The buildjet runners no longer work, breaking these workflows. This maps them to GitHub-hosted runners, matching the fix already made in [viamrobotics/rust-utils#178](https://github.com/viamrobotics/rust-utils/pull/178):

- `buildjet-*-ubuntu-2204-arm` (native arm64 builds) -> `github-linux-arm64-8core`
- `buildjet-*-ubuntu-2204` (x86) -> `ubuntu-large`

These are all native per-arch builds (arm64 container images / `--platform linux/arm64`), so the arm jobs map to the arm GitHub runner. Where present, the now-unused buildjet labels are also dropped from `.github/actionlint.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)